### PR TITLE
Added AssetBundle for jquery.mousewheel.js

### DIFF
--- a/FancyBox.php
+++ b/FancyBox.php
@@ -76,7 +76,7 @@ class FancyBox extends Widget {
         $assets = FancyBoxAsset::register($view);
 
         if ($this->mouse) {
-            $view->registerJsFile('@web/vendor/newerton/jquery-mousewheel/jquery.mousewheel' . (!YII_DEBUG ? '.min' : '') . '.js', ['depends' => \newerton\fancybox\FancyBoxAsset::className()]);
+            MousewheelAsset::register($view);
         }
 
         if ($this->helpers) {

--- a/MousewheelAsset
+++ b/MousewheelAsset
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Created by mulat.
+ * User: mulat
+ * Date: 07.05.2015
+ * Time: 13:17
+ */
+namespace newerton\fancybox;
+
+use yii\web\AssetBundle;
+
+class MousewheelAsset extends AssetBundle
+{
+    public $sourcePath = '@vendor/newerton/jquery-mousewheel/';
+
+    public $js = [];
+
+    public $css = [];
+
+    public $depends = [
+        'yii\web\JqueryAsset',
+    ];
+
+    public function registerAssetFiles($view) {
+        $this->js[] = 'jquery.mousewheel' . (!YII_DEBUG ? '.min' : '') . '.js';
+        parent::registerAssetFiles($view);
+    }
+}

--- a/MousewheelAsset
+++ b/MousewheelAsset
@@ -19,6 +19,7 @@ class MousewheelAsset extends AssetBundle
 
     public $depends = [
         'yii\web\JqueryAsset',
+        'newerton\fancybox\FancyBoxAsset',
     ];
 
     public function registerAssetFiles($view) {

--- a/MousewheelAsset
+++ b/MousewheelAsset
@@ -11,7 +11,7 @@ use yii\web\AssetBundle;
 
 class MousewheelAsset extends AssetBundle
 {
-    public $sourcePath = '@vendor/newerton/jquery-mousewheel/';
+    public $sourcePath = '@vendor/newerton/jquery-mousewheel/source/';
 
     public $js = [];
 


### PR DESCRIPTION
Fixed the situation, when '@web/vendor/newerton/jquery-mousewheel/' is not accessable.
The file jquery.mousewheel.js cannot be registred with a help of FancyboxAsset bundle, so I created the new one and registred it directly in the Fancybox widget.
